### PR TITLE
Allow floats with leading zero to be parsed.

### DIFF
--- a/json_stream_parser.py
+++ b/json_stream_parser.py
@@ -152,8 +152,8 @@ def _load_num(ch: str, fp) -> Tuple[Union[int, float], str]:
     digits, ch = _maybe_digits(fp)  # NOTE: ch may be ''
     s += digits
 
-    # zero is special
-    if is_zero:
+    # zero is special, when not followed by .
+    if is_zero and ch != '.':
         if digits:
             raise JSONDecodeError('digits follows zero')
         return 0, ''

--- a/test_json_stream_parser.py
+++ b/test_json_stream_parser.py
@@ -9,6 +9,7 @@ def test_ok_coverage():
         0
         -0
         123
+        0.1
         1.2
         1.123
         1.3e9


### PR DESCRIPTION
Fix to enable parsing floats with leading zeros (e.g. 0.123).